### PR TITLE
Fix sniffer metadata

### DIFF
--- a/src/main/java/net/minestom/server/entity/Metadata.java
+++ b/src/main/java/net/minestom/server/entity/Metadata.java
@@ -3,6 +3,7 @@ package net.minestom.server.entity;
 import net.kyori.adventure.text.Component;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.entity.metadata.animal.FrogMeta;
+import net.minestom.server.entity.metadata.animal.SnifferMeta;
 import net.minestom.server.entity.metadata.animal.tameable.CatMeta;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.network.NetworkBuffer;
@@ -112,6 +113,10 @@ public final class Metadata {
 
     public static Entry<FrogMeta.Variant> FrogVariant(@NotNull FrogMeta.Variant value) {
         return new MetadataImpl.EntryImpl<>(TYPE_FROG_VARIANT, value, NetworkBuffer.FROG_VARIANT);
+    }
+
+    public static Entry<SnifferMeta.State> SnifferState(@NotNull SnifferMeta.State value) {
+        return new MetadataImpl.EntryImpl<>(TYPE_SNIFFER_STATE, value, NetworkBuffer.SNIFFER_STATE);
     }
 
     public static Entry<Point> Vector3(@NotNull Point value) {

--- a/src/main/java/net/minestom/server/entity/metadata/animal/SnifferMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/SnifferMeta.java
@@ -13,11 +13,11 @@ public class SnifferMeta extends AnimalMeta {
     }
 
     public @NotNull State getState() {
-        return State.VALUES[super.metadata.getIndex(OFFSET, (byte) 0)];
+        return super.metadata.getIndex(OFFSET, State.IDLING);
     }
 
     public void setState(@NotNull State value) {
-        super.metadata.setIndex(OFFSET, Metadata.Byte((byte) value.ordinal()));
+        super.metadata.setIndex(OFFSET, Metadata.SnifferState(value));
     }
 
     public int getFinishingDigTime() {

--- a/src/main/java/net/minestom/server/entity/metadata/animal/SnifferMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/SnifferMeta.java
@@ -36,6 +36,6 @@ public class SnifferMeta extends AnimalMeta {
         SNIFFING,
         SEARCHING,
         DIGGING,
-        RISING;
+        RISING
     }
 }

--- a/src/main/java/net/minestom/server/entity/metadata/animal/SnifferMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/SnifferMeta.java
@@ -37,7 +37,5 @@ public class SnifferMeta extends AnimalMeta {
         SEARCHING,
         DIGGING,
         RISING;
-
-        private final static State[] VALUES = values();
     }
 }

--- a/src/main/java/net/minestom/server/network/NetworkBuffer.java
+++ b/src/main/java/net/minestom/server/network/NetworkBuffer.java
@@ -12,6 +12,7 @@ import net.kyori.adventure.text.Component;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.metadata.animal.FrogMeta;
+import net.minestom.server.entity.metadata.animal.SnifferMeta;
 import net.minestom.server.entity.metadata.animal.tameable.CatMeta;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.network.packet.server.play.data.DeathLocation;
@@ -70,6 +71,7 @@ public final class NetworkBuffer {
     public static final Type<DeathLocation> DEATH_LOCATION = NetworkBufferTypes.DEATH_LOCATION;
     public static final Type<CatMeta.Variant> CAT_VARIANT = NetworkBufferTypes.CAT_VARIANT;
     public static final Type<FrogMeta.Variant> FROG_VARIANT = NetworkBufferTypes.FROG_VARIANT;
+    public static final Type<SnifferMeta.State> SNIFFER_STATE = NetworkBufferTypes.SNIFFER_STATE;
     public static final Type<Point> VECTOR3 = NetworkBufferTypes.VECTOR3;
     public static final Type<Quaternion> QUATERNION = NetworkBufferTypes.QUATERNION;
 

--- a/src/main/java/net/minestom/server/network/NetworkBufferTypes.java
+++ b/src/main/java/net/minestom/server/network/NetworkBufferTypes.java
@@ -6,6 +6,7 @@ import net.minestom.server.coordinate.Point;
 import net.minestom.server.coordinate.Vec;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.metadata.animal.FrogMeta;
+import net.minestom.server.entity.metadata.animal.SnifferMeta;
 import net.minestom.server.entity.metadata.animal.tameable.CatMeta;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.item.Material;
@@ -549,6 +550,15 @@ final class NetworkBufferTypes {
             buffer -> {
                 final int ordinal = buffer.read(VAR_INT);
                 return FrogMeta.Variant.values()[ordinal];
+            });
+    static final TypeImpl<SnifferMeta.State> SNIFFER_STATE = new TypeImpl<>(SnifferMeta.State.class,
+            (buffer, value) -> {
+                buffer.write(VAR_INT, value.ordinal());
+                return -1;
+            },
+            buffer -> {
+                final int ordinal = buffer.read(VAR_INT);
+                return SnifferMeta.State.values()[ordinal];
             });
     static final TypeImpl<Point> VECTOR3 = new TypeImpl<>(Point.class,
             (buffer, value) -> {


### PR DESCRIPTION
Same issue as when cat/frog meta was broken. They have specific metadata types instead of just a varint 😢 